### PR TITLE
Add overwrite cookie config

### DIFF
--- a/app/controllers/concerns/refer/controller.rb
+++ b/app/controllers/concerns/refer/controller.rb
@@ -15,7 +15,7 @@ module Refer
     private
 
     def set_refer_cookie(param_name: Refer.param_name, cookie_name: Refer.cookie_name)
-      if (code = params[param_name])
+      if (code = params[param_name]) && (Refer.overwrite_cookie || cookies[cookie_name].blank?)
         cookies[cookie_name] = Refer.cookie(code)
       end
     end

--- a/lib/refer.rb
+++ b/lib/refer.rb
@@ -9,6 +9,7 @@ module Refer
   config_accessor :cookie_length, default: 30.days
   config_accessor :cookie_name, default: :refer_code
   config_accessor :param_name, default: :ref
+  config_accessor :overwrite_cookie, default: true
 
   class Error < StandardError; end
   class AlreadyReferred < Error; end

--- a/test/models/refer/referral_code_test.rb
+++ b/test/models/refer/referral_code_test.rb
@@ -18,6 +18,18 @@ class Refer::ReferralCodeTest < ActiveSupport::TestCase
   end
 
   test "generates referral codes automatically" do
+    original_generator = Refer.code_generator
+    Refer.code_generator = ->(referrer) { SecureRandom.alphanumeric(8) }
     assert_not_nil users(:one).referral_codes.create!.code
+  ensure
+    Refer.code_generator = original_generator
+  end
+
+  test "does not generate referral code automatically if empty generator config" do
+    original_generator = Refer.code_generator
+    Refer.code_generator = nil
+    assert_nil users(:one).referral_codes.create.code
+  ensure
+    Refer.code_generator = original_generator
   end
 end


### PR DESCRIPTION
This adds the ability to configure whether the cookie is overwritten when a page is visited with a different referral cookie.

Enabled by default, but when disabled it keep the original referral code until it expires without overwriting.