### PR TITLE
Change migration version to 6.1

### DIFF
--- a/db/migrate/20240701172643_create_refer_visits.rb
+++ b/db/migrate/20240701172643_create_refer_visits.rb
@@ -1,4 +1,4 @@
-class CreateReferVisits < ActiveRecord::Migration[7.2]
+class CreateReferVisits < ActiveRecord::Migration[6.1]
   def change
     create_table :refer_visits do |t|
       t.belongs_to :referral_code, null: false, foreign_key: { to_table: :refer_referral_codes }


### PR DESCRIPTION
## Pull Request

**Summary:**

I got this error when running migrations on Rails 7.1 app:

```
ArgumentError: Unknown migration version "7.2"; expected one of "4.2", "5.0", "5.1", "5.2", "6.0", "6.1", "7.0", "7.1" (ArgumentError)
```

**Description:**

The problem is that the migration used version `7.2`, even though `Rails 6.1` is the minimum Rails version supported. I've changed the version to `6.1` to match the other migrations.

**Testing:**

I have NOT tested this change, other than editing the migration in my own codebase. But I don't see why this change would cause any problems.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines