### PR TITLE
Make set_refer_cookie public and more flexible

### DIFF
--- a/lib/refer/controller.rb
+++ b/lib/refer/controller.rb
@@ -12,14 +12,12 @@ module Refer
       Refer.refer(code: cookies[cookie_name], referee: referee)
     end
 
-    private
-
-    def set_refer_cookie(param_name: Refer.param_name, cookie_name: Refer.cookie_name)
-      code = params[param_name]
+    def set_refer_cookie(param_name: Refer.param_name, cookie_name: Refer.cookie_name, code: nil, track_visits: Refer.track_visits)
+      code ||= params[param_name]
       return if code.blank?
-
+  
       cookies[cookie_name] = Refer.cookie(code) if Refer.overwrite_cookie || cookies[cookie_name].blank?
-      ReferralCode.find_by(code: code)&.track_visit(request) if Refer.track_visits
+      ReferralCode.find_by(code: code)&.track_visit(request) if track_visits
     end
   end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
I made `set_refer_cookie` a public method, allowed passing in a `code`, and overriding `track_visits`.

**Description:**
The reason for these changes are to provide more flexibility on when and how refer cookies are set.

For example, let's say you have an app where users can create public listings. When someone visits a user's listing, you want to set a cookie to "reward" the user if someone new signs up through their public listing.

With the existing Refer implementation, this requires ensuring that the public listings always have a `?ref=code` parameter set. But with a more flexible `set_refer_cookie` method we can do something like this:

```ruby
class ListingsController < ApplicationController
  def show
    @listing = Listing.find(params[:id])

    # Set cookie
    code = @listing.user.referral_codes.first.code
    set_refer_cookie(code: code, track_visit: false)
  end
end
```

**Testing:**
I haven't tested it yet 😅

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**

If you approve of this change, I can add tests.
