### PR TITLE
Delegated referrer could be nil

### DIFF
--- a/lib/refer/model.rb
+++ b/lib/refer/model.rb
@@ -6,7 +6,7 @@ module Refer
       has_many :referral_codes, as: :referrer, class_name: "Refer::ReferralCode", dependent: :destroy
       has_many :referrals, as: :referrer, class_name: "Refer::Referral", dependent: :destroy
       has_one :referral, as: :referee, class_name: "Refer::Referral", dependent: :destroy
-      delegate :referrer, to: :referral
+      delegate :referrer, to: :referral, allow_nil: true
     end
   end
 end

--- a/test/refer_test.rb
+++ b/test/refer_test.rb
@@ -48,6 +48,10 @@ class ReferTest < ActiveSupport::TestCase
     assert_equal users(:one), users(:two).referrer
   end
 
+  test "referrer when nil" do
+    assert_nil users(:new).referrer
+  end
+
   test "referral_completed callback" do
     old_callback = Refer.referral_completed
     referral = refer_referrals(:one)


### PR DESCRIPTION
## Pull Request

**Summary:**
Fix error when accessing `user.referrer` for users who signed up without a referral code.

**Description:**
Currently, an `ActiveSupport::DelegationError` is raised when trying to access the `referrer` for a user without a referral:

```ruby
ActiveSupport::DelegationError: referrer delegated to referral, but referral is nil
```

**Steps to Reproduce:**
```ruby
app(dev)> u = User.first
app(dev)> u.referrer
# Raises ActiveSupport::DelegationError
```

**Checklist:**

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
