### PR TITLE
add validation to prevent self-referrals

### DIFF
--- a/app/models/refer/referral.rb
+++ b/app/models/refer/referral.rb
@@ -10,6 +10,14 @@ module Refer
       self.referrer = referral_code&.referrer
     end
 
+    validate :blocks_self_referral
+
+    def blocks_self_referral
+      if referrer == referee
+        errors.add(:referee_id, "You can't refer yourself")
+      end
+    end
+
     def complete!(**attributes)
       return if completed_at?
 

--- a/test/refer_test.rb
+++ b/test/refer_test.rb
@@ -17,6 +17,12 @@ class ReferTest < ActiveSupport::TestCase
     end
   end
 
+  test "refer self" do
+    assert_no_difference "Refer::Referral.count" do
+      Refer.refer(code: refer_referral_codes(:one).code, referee: users(:one))
+    end
+  end
+
   test "refer already referred" do
     assert_no_difference "Refer::Referral.count" do
       Refer.refer(code: refer_referral_codes(:one).code, referee: users(:two))


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
Adds a validation on Referral which blocks self-referrals

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->
Discussion https://github.com/excid3/refer/discussions/46

**Description:**
<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->
This fixes the existing situation which allows self-referrals:

```ruby
user = User.first
referral_code = user.referral_codes.create
Refer.refer(code: referral_code.code, referee: user)
```

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->
Added test to ensure that the count of Referrals does not increase if both the referrer and referee are the same.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
